### PR TITLE
use Extract instead of Pick for positions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1592,8 +1592,7 @@ export interface SideSheetProps {
   shouldCloseOnEscapePress?: boolean
   width?: string | number
   containerProps?: PaneOwnProps & BoxProps<'div'>
-  // @ts-ignore
-  position?: Pick<PositionTypes, 'top' | 'bottom' | 'left' | 'right'>
+  position?: Extract<PositionTypes, 'top' | 'bottom' | 'left' | 'right'>
   preventBodyScrolling?: boolean
 }
 


### PR DESCRIPTION
Updated typescript definitions to accurately reflect Positions for SideSheet.
